### PR TITLE
add bourbaki.regex with notes and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Building the regex with `+` (and `|` in some cases).
 
 | Package             | Github                                          | Sample                                                                          | Notes                  |
 |---------------------|-------------------------------------------------|---------------------------------------------------------------------------------|------------------------|
-| **prerex**          | [➚](https://github.com/manoss96/pregex)         | `Capture(OneOrMore(AnyUppercaseLetter())) + " " + Either("(", "[")`             | [***](#pregex)         |
+| **pregex**          | [➚](https://github.com/manoss96/pregex)         | `Capture(OneOrMore(AnyUppercaseLetter())) + " " + Either("(", "[")`             | [***](#pregex)         |
 | **humre**           | [➚](https://github.com/asweigart/humre)         | `group(SOMETHING) + " " + noncap_group(either(OPEN_PARENTHESIS, OPEN_BRACKET))` | [***](#humre)          |
 | **bourbaki.regex**  | [➚](https://github.com/bourbaki-py/regex)       | `"hello" + L(",").optional + Whitespace[1:] + "world" + L("!").optional`        | [***](#bourbaki-regex) |
 | **objective_regex** | [➚](https://github.com/VRGhost/objective_regex) | `Text("hello").times.any() + Raw("\s").times(5) + Text("world!").times.many()`  |                        |
@@ -201,10 +201,9 @@ Notes:
 
 ### bourbaki.regex
 
+Comprehensive implementation combining additive and flow styles with syntax that can be quite terse or more verbose as needed.
+
 Example:
-```regexp
-r"(?P<title>.+) (\(|\[)(?P<key>[A-Z]+)-(?P<number>\d+)(\)|\])"
-```
 ```python
 uppercase_word = C["A":"Z"][1:]
 number = Digit[1:]

--- a/README.md
+++ b/README.md
@@ -57,13 +57,14 @@ Functional flow style of dotted function chains.
 
 Building the regex with `+` (and `|` in some cases).
 
-| Package             | Github                                          | Sample                                                                          | Notes          |
-|---------------------|-------------------------------------------------|---------------------------------------------------------------------------------|----------------|
-| **prerex**          | [➚](https://github.com/manoss96/pregex)         | `Capture(OneOrMore(AnyUppercaseLetter())) + " " + Either("(", "[")`             | [***](#pregex) |
-| **humre**           | [➚](https://github.com/asweigart/humre)         | `group(SOMETHING) + " " + noncap_group(either(OPEN_PARENTHESIS, OPEN_BRACKET))` | [***](#humre)  |
-| **objective_regex** | [➚](https://github.com/VRGhost/objective_regex) | `Text("hello").times.any() + Raw("\s").times(5) + Text("world!").times.many()`  |                |
-| **reggie-dsl**      | [➚](https://github.com/romilly/reggie-dsl)      | `dd = multiple(digit, 2, 2); name(dd + slash + dd + slash + year, 'date')`      |                |
-| **reb**             | [➚](https://github.com/workingenius/reb)        | `"n(nic(':/?#'), 1) + ':' + n01('//' + n(nic('/?#'))) + n(nic('?#'))"`          |                |
+| Package             | Github                                          | Sample                                                                          | Notes                  |
+|---------------------|-------------------------------------------------|---------------------------------------------------------------------------------|------------------------|
+| **prerex**          | [➚](https://github.com/manoss96/pregex)         | `Capture(OneOrMore(AnyUppercaseLetter())) + " " + Either("(", "[")`             | [***](#pregex)         |
+| **humre**           | [➚](https://github.com/asweigart/humre)         | `group(SOMETHING) + " " + noncap_group(either(OPEN_PARENTHESIS, OPEN_BRACKET))` | [***](#humre)          |
+| **bourbaki.regex**  | [➚](https://github.com/bourbaki-py/regex)       | `"hello" + L(",").optional + Whitespace[1:] + "world" + L("!").optional`        | [***](#bourbaki-regex) |
+| **objective_regex** | [➚](https://github.com/VRGhost/objective_regex) | `Text("hello").times.any() + Raw("\s").times(5) + Text("world!").times.many()`  |                        |
+| **reggie-dsl**      | [➚](https://github.com/romilly/reggie-dsl)      | `dd = multiple(digit, 2, 2); name(dd + slash + dd + slash + year, 'date')`      |                        |
+| **reb**             | [➚](https://github.com/workingenius/reb)        | `"n(nic(':/?#'), 1) + ':' + n01('//' + n(nic('/?#'))) + n(nic('?#'))"`          |                        |
 
 #### 3. Format strings
 
@@ -196,6 +197,48 @@ Notes:
 - Nice cheat sheets for quick function lookup.
 - No support for named capture groups.
 - Took the most time for me fighting with this to get the result I wanted.
+
+
+### bourbaki.regex
+
+Example:
+```regexp
+r"(?P<title>.+) (\(|\[)(?P<key>[A-Z]+)-(?P<number>\d+)(\)|\])"
+```
+```python
+uppercase_word = C["A":"Z"][1:]
+number = Digit[1:]
+pattern = (
+    ANYCHAR[1:] ("title") + 
+    " [" +
+    uppercase_word ("key") + 
+    "-" +
+    number ("number") +
+    "]"
+)
+pattern.fullmatch("This is a title [KEY-123]").groupdict()
+# {'title': 'This is a title', 'key': 'KEY', 'number': '123'}
+```
+
+Notes:
+- Supports all standard regex constructs from the `re` module:
+  - Named and anonymous capture groups
+  - Back-references (specifiable as references to other literal regex objects in your code)
+  - Lookahead and lookbehind assertions
+  - If/else conditions
+  - local sub-pattern compilation flags (e.g. `re.IGNORECASE`)
+- Also optionally supports some extended options from the more featureful `regex`:
+  - Variable-length lookbehind assertions (also statically checks that you _don't_ do this when using `re`)
+  - Atomic groups (also supports this through a back-reference trick when using `re` - you don't have to remember this trick)
+- Static validation of patterns
+  - Referential integrity of back-references when specified either by name or by python object reference.
+  - Length constraints on lookbehind assertions (in case the implementation, like `re`, doesn't support variable length here)
+- Composition optimization
+  - E.g. alternation of a set of character classes results in a single character class rather than a syntactic alternation:
+    `C["a":"z"] | C["0": "9"]` transpiles to `[a-z0-9]` and not e.g. `[a-z]|[0-9]` which could be slightly less efficient and readable.
+- Transpiles to standard regex patterns which you can acccess via `.pattern` (raw string) or `.compile()` (compiled regex) in
+  case you want to use the library only for composition of patterns and not matching.
+
 
 ### scanf
 

--- a/README.md
+++ b/README.md
@@ -229,14 +229,15 @@ Notes:
 - Also optionally supports some extended options from the more featureful `regex`:
   - Variable-length lookbehind assertions (also statically checks that you _don't_ do this when using `re`)
   - Atomic groups (also supports this through a back-reference trick when using `re` - you don't have to remember this trick)
-- Static validation of patterns
+- Static validation of patterns with nice error messages
   - Referential integrity of back-references when specified either by name or by python object reference.
   - Length constraints on lookbehind assertions (in case the implementation, like `re`, doesn't support variable length here)
-- Composition optimization
+- Compositional syntax optimizations
   - E.g. alternation of a set of character classes results in a single character class rather than a syntactic alternation:
     `C["a":"z"] | C["0": "9"]` transpiles to `[a-z0-9]` and not e.g. `[a-z]|[0-9]` which could be slightly less efficient and readable.
 - Transpiles to standard regex patterns which you can acccess via `.pattern` (raw string) or `.compile()` (compiled regex) in
-  case you want to use the library only for composition of patterns and not matching.
+  case you want to use the library only for composition of patterns and not matching. Otherwise you can access all the usual methods
+  on the regex object itself (`match`, `search`, `fullmatch`, etc).
 
 
 ### scanf


### PR DESCRIPTION
Hello @mikaelho !

I saw your repo about readable regex in python mentioned on Python Bytes and I just wanted to make you aware of one library I maintain that you may have missed.

I haven't added anything to it since 2020 but as you say, there's not a ton to these things - once it was implemented and working, that was kind of it. I would like to add support for `regex`'s fuzzy matching feature in the future but there's not a lot to do - unless I have users because they found the library though Python Bytes and the feature requests start coming in 😉.

I kept the README update to the simple pattern you define there, but in case you're interested, here's an example of doing something more complex with if/else conditions and back-references (parsing [ISO-3986 standard URIs](https://www.rfc-editor.org/rfc/rfc3986)):
https://github.com/bourbaki-py/regex/blob/master/tests/test_regex.py#L110

I hope you'll consider adding `bourbaki.regex` to your write-up because it's been out there for a couple years and I have no idea if anyone is using it besides myself. It doesn't seem to be anywhere in the top dozens of results for "readable regex" when I search PyPI and I don't really know of a way to make it known other than letting people know about it like I'm doing here.

If you decide not to include it, no offense taken but it would be nice to know what criteria it doesn't meet for you. I'd like it to be ergonomic for people to use but aesthetics is in the eye of the beholder (PS - there are other more verbose ways to implement the example in your README so I'm happy to update to those if you find the slice/operator overloading just as opaque as regex itself 😄).

Thanks,
Matt Hawthorn